### PR TITLE
Fix/tasks page

### DIFF
--- a/socialbright-backend/api/tasks.py
+++ b/socialbright-backend/api/tasks.py
@@ -1,0 +1,87 @@
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+from db.session import get_db
+from db.models import Task, Client
+from schemas.tasks import TaskCreate, TaskResponse
+from typing import List
+from dependencies.auth import get_current_user
+
+router = APIRouter()
+
+@router.get("/clients/{client_id}/tasks", response_model=List[TaskResponse])
+def get_client_tasks(
+    client_id: int,
+    db: Session = Depends(get_db),
+    user = Depends(get_current_user)
+):
+    tasks = db.query(Task).filter(Task.client_id == client_id).all()
+    return [
+        TaskResponse(
+            id=task.id,
+            client_id=task.client_id,
+            client_name="",  # optional: add join for name if needed
+            task=task.task,
+            due_date=task.due_date,
+            status=task.status,
+            view=task.view,
+            subtasks=task.subtasks or []
+        )
+        for task in tasks
+    ]
+
+@router.post("/clients/{client_id}/tasks", response_model=TaskResponse)
+def create_client_task(
+    client_id: int,
+    task: TaskCreate,
+    db: Session = Depends(get_db),
+    user = Depends(get_current_user)
+):
+    new_task = Task(
+        client_id=client_id,
+        tenant_id=user.tenant_id,
+        user_id=user.id,
+        task=task.task,
+        status=task.status,
+        due_date=task.due_date,
+        subtasks=task.subtasks or [],
+        view='client'
+    )
+    db.add(new_task)
+    db.commit()
+    db.refresh(new_task)
+    return TaskResponse(
+        id=new_task.id,
+        client_id=new_task.client_id,
+        client_name="",  # optional
+        task=new_task.task,
+        due_date=new_task.due_date,
+        status=new_task.status,
+        view=new_task.view,
+        subtasks=new_task.subtasks or []
+    )
+
+@router.get("/tasks", response_model=List[TaskResponse])
+def get_all_tasks_for_tenant(
+    db: Session = Depends(get_db),
+    user = Depends(get_current_user)
+):
+    tasks = (
+        db.query(Task, Client.first_name, Client.last_name)
+        .outerjoin(Client, Task.client_id == Client.id)
+        .filter(Task.tenant_id == user.tenant_id)
+        .all()
+    )
+
+    return [
+        TaskResponse(
+            id=task.id,
+            client_id=task.client_id,
+            client_name=(f"{first} {last}".strip() if first else "General"),
+            task=task.task,
+            due_date=task.due_date,
+            status=task.status,
+            view=task.view or "client",
+            subtasks=task.subtasks or []
+        )
+        for (task, first, last) in tasks
+    ]

--- a/socialbright-frontend/src/tenants/tenant1/pages/User/TasksPage.jsx
+++ b/socialbright-frontend/src/tenants/tenant1/pages/User/TasksPage.jsx
@@ -20,29 +20,25 @@ export default function TasksPage() {
   }, []);
 
   const fetchTasks = async () => {
-  const clientId = localStorage.getItem('clientId');
-  if (!clientId) return;
-  try {
-    const res = await axios.get(`${API_BASE}/clients/${clientId}/tasks`, getAuthHeaders());
-    console.log("✅ tasks fetched:", res.data);
-    setTasks(res.data);
-  } catch (err) {
-    console.error('Error fetching tasks:', err);
-  }
-};
+    try {
+      const res = await axios.get(`${API_BASE}/api/tasks`, getAuthHeaders());
+      console.log("✅ tasks fetched:", res.data);
+      setTasks(res.data);
+    } catch (err) {
+      console.error('Error fetching tasks:', err);
+    }
+  };
 
   const addTask = async () => {
     try {
-      const clientId = localStorage.getItem('clientId');
       const newTask = {
-        view: 'client',
-        due_date: '',
-        status: 'To Do',
-        client_name: 'New Client',
         task: 'New Task',
+        status: 'To Do',
+        due_date: '',
+        client_id: null,
         subtasks: [],
       };
-      const res = await axios.post(`${API_BASE}/clients/${clientId}/tasks`, newTask, getAuthHeaders());
+      const res = await axios.post(`${API_BASE}/api/tasks`, newTask, getAuthHeaders());
       setTasks([...tasks, res.data]);
     } catch (err) {
       console.error('Error adding task:', err);
@@ -51,14 +47,9 @@ export default function TasksPage() {
 
   const updateTask = async (taskId, updatedFields) => {
     try {
-      const clientId = localStorage.getItem('clientId');
       const existing = tasks.find((t) => t.id === taskId);
       const updatedTask = { ...existing, ...updatedFields };
-      const res = await axios.put(
-        `${API_BASE}/clients/${clientId}/tasks/${taskId}`,
-        updatedTask,
-        getAuthHeaders()
-      );
+      const res = await axios.put(`${API_BASE}/api/tasks/${taskId}`, updatedTask, getAuthHeaders());
       setTasks((prev) => prev.map((t) => (t.id === taskId ? res.data : t)));
     } catch (err) {
       console.error('Error updating task:', err);
@@ -67,8 +58,7 @@ export default function TasksPage() {
 
   const deleteTask = async (taskId) => {
     try {
-      const clientId = localStorage.getItem('clientId');
-      await axios.delete(`${API_BASE}/clients/${clientId}/tasks/${taskId}`, getAuthHeaders());
+      await axios.delete(`${API_BASE}/api/tasks/${taskId}`, getAuthHeaders());
       setTasks((prev) => prev.filter((task) => task.id !== taskId));
     } catch (err) {
       console.error('Error deleting task:', err);
@@ -97,7 +87,7 @@ export default function TasksPage() {
   });
 
   return (
-    <div className="min-h-screen bg-gray-50 px-4 py-16 text-black text-sm">
+    <div className="min-h-screen bg-gray-100 px-4 py-16 text-black text-sm">
       <div className="max-w-5xl mx-auto">
         <h1 className="text-xl font-bold mb-4 text-center">Client Tasks</h1>
 
@@ -141,7 +131,7 @@ export default function TasksPage() {
               key={task.id}
               className="bg-white p-4 rounded-lg shadow-sm border border-gray-200"
             >
-              <h2 className="text-sm font-semibold">{task.client_name}</h2>
+              <h2 className="text-sm font-semibold">{task.client_name || 'General'}</h2>
               <p className="text-sm text-gray-800 mb-2">{task.task}</p>
               <ul className="ml-4 list-disc space-y-1 text-sm text-gray-800">
                 {task.subtasks?.map((sub, i) => (


### PR DESCRIPTION
1. Fixed fetchTasks() to use /api/tasks
2. Updated addTask, updateTask, deleteTask to work with tenant-wide routes
3. Removed clientId dependency
4. Cleaned up logic for subtasks, status, etc.
5. Rewrote GET /api/tasks to return shaped responses with client_name, default values
6. Added subtasks = [] fallback
7. Ensured valid view and client_id in output
8. Confirmed or adjusted TaskResponse (especially client_id: int)
9. Re-linked all orphaned tasks to a valid client